### PR TITLE
Update googleads/googleads-php-lib version from ~35.0.0 to ^35.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "php": ">=5.5.9",
     "ext-soap": "*",
     "illuminate/console": ">=5.1",
-    "illuminate/support": "~5.1",
-    "googleads/googleads-php-lib": "~35.0.0"
+    "illuminate/support": "^5.1",
+    "googleads/googleads-php-lib": "^35.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Due to the `composer.json` version string for `googleads/googleads-php-lib`, new minor updates to that library are not available.